### PR TITLE
Fix local server start

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ npm start
 
 5. Abra o navegador e acesse:
 ```
-http://localhost:3000
+http://localhost:4000
 ```
 
 ### Caso queira contribuir

--- a/api/server.js
+++ b/api/server.js
@@ -75,10 +75,12 @@ app.get('*', (req, res) => {
     res.sendFile(path.join(__dirname, '../public/index.html'));
 });
 
-// 🔹 INICIA O SERVIDOR
-// app.listen(PORT, () => {
-//     console.log(`Servidor rodando em http://localhost:${PORT}`);
-// });
+// 🔹 INICIA O SERVIDOR QUANDO EXECUTADO DIRETAMENTE
+if (require.main === module) {
+    app.listen(PORT, () => {
+        console.log(`Servidor rodando em http://localhost:${PORT}`);
+    });
+}
 
 // 🔹 EXPORTAÇÃO PARA O VERCEL ENTENDER
 module.exports = app;


### PR DESCRIPTION
## Summary
- start Express server automatically when running `npm start`
- update README with correct localhost URL

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68426502cab4833197daae1abbe7d501