### PR TITLE
Fix Portuguese plural in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,4 +101,4 @@ Este projeto está licenciado sob a Licença MIT. Veja o arquivo [LICENSE](LICEN
 ## Avisos
 - Os mapas podem estar desatualizados com algumas informações, se encontrar algum erro, entre em contato abrindo uma PR ou Issue para corrigir;
 - Certifique-se de respeitar as licenças dos dados e mapas utilizados;
-- Mapas interativos do Arena Breakout Infinite foram baseado nos mapas interativos do [Fandom](https://arena-breakout-infinite.fandom.com/wiki/Main);
+- Mapas interativos do Arena Breakout Infinite foram baseados nos mapas interativos do [Fandom](https://arena-breakout-infinite.fandom.com/wiki/Main);


### PR DESCRIPTION
## Summary
- fix plural form in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684266718efc8331a6d2a6103dc2589d