### PR TITLE
Update localhost port reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,19 @@ cd ABI-InteractiveMaps
 npm install
 ```
 
-4. Execute o projeto:
+4. Execute o projeto (a aplicação usa a porta `4000` por padrão):
 ```bash
 npm start
 ```
 
+Caso queira utilizar a porta `3000`, defina a variável de ambiente `PORT`:
+```bash
+PORT=3000 npm start
+```
+
 5. Abra o navegador e acesse:
 ```
-http://localhost:3000
+http://localhost:4000
 ```
 
 ### Caso queira contribuir


### PR DESCRIPTION
## Summary
- clarify default port 4000 in README
- document `PORT=3000` example

## Testing
- `npm start` (failed: Cannot find module 'express')
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684266766bac8331997959058b5ae0f8