### PR TITLE
Fix translation path

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -34,7 +34,7 @@ app.get('/api/coordinates/:mapName', (req, res) => {
     const mapName = req.params.mapName;
     const lang = req.query.lang || 'en';
     const filePath = path.join(__dirname, `../public/coordinates/${mapName}.json`);
-    const translationPath = path.join(__dirname, `../public/locales/${lang}.json`);
+    const translationPath = path.join(__dirname, `./locales/${lang}.json`);
 
     if (!fs.existsSync(filePath)) {
         return res.status(404).json({ error: "Mapa não encontrado" });


### PR DESCRIPTION
## Summary
- ensure coordinates API uses local locales folder for translations

## Testing
- `node -e "const app = require('./api/server'); app.listen(4000, ()=>console.log('server running'));"`
- `curl -s http://localhost:4000/api/coordinates/valley?lang=pt-br | jq '.markers[0]'`

------
https://chatgpt.com/codex/tasks/task_e_6842666c3d188331acfda40c13bce1eb