### PR TITLE
Add Jest test infrastructure

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "main.js",
   "scripts": {
     "start": "node api/server.js",
-    "dev": "node api/server.js"
+    "dev": "node api/server.js",
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -14,5 +15,9 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.21.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^7.1.1"
   }
 }

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,0 +1,18 @@
+const request = require('supertest');
+const app = require('../api/server');
+
+describe('API Endpoints', () => {
+  test('GET /api/maps responds with array of maps', async () => {
+    const response = await request(app).get('/api/maps');
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.body)).toBe(true);
+    expect(response.body.length).toBeGreaterThan(0);
+  });
+
+  test('GET /api/coordinates/:mapName returns map data', async () => {
+    const response = await request(app).get('/api/coordinates/farm');
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('mapName', 'Farm');
+    expect(response.body).toHaveProperty('markers');
+  });
+});


### PR DESCRIPTION
## Summary
- install Jest and Supertest
- add test script to package.json
- create tests for map endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842667aff908331895205154bb141e3